### PR TITLE
Fix typo in Vim post from October 27, 2015

### DIFF
--- a/2015/2015-10-27-vim-and-python-a-match-made-in-heaven.markdown
+++ b/2015/2015-10-27-vim-and-python-a-match-made-in-heaven.markdown
@@ -387,7 +387,7 @@ if has('gui_running')
   set background=dark
   colorscheme solarized
 else
-  colorscheme Zenburn
+  colorscheme zenburn
 endif
 ```
 


### PR DESCRIPTION
This theme needs to be all lowercase when enabling it or it causes an error.
