### PR TITLE
React.render is now ReactDOM.render (React v 0.14)

### DIFF
--- a/2015/2015-03-25-the-ultimate-flask-front-end-part-2.markdown
+++ b/2015/2015-03-25-the-ultimate-flask-front-end-part-2.markdown
@@ -75,7 +75,7 @@ var countries = [
   {"name": "Spain"}, {"name": "Poland"}, {"name": "Haiti"}
 ];
 
-React.render(
+ReactDOM.render(
   <DynamicSearch items={ countries } />,
   document.getElementById('main')
 );
@@ -245,6 +245,7 @@ Ready for a quick test? Update *index.html*:
     </div>
     <!-- scripts -->
     <script src="{{ url_for('static', filename='bower_components/react/react.min.js') }}"></script>
+    <script src="{{ url_for('static', filename='bower_components/react/react-dom.min.js') }}"></script>
     <script src="{{ url_for('static', filename='bower_components/jquery/dist/jquery.min.js') }}"></script>
     <script src="{{ url_for('static', filename='bower_components/bootstrap/dist/js/bootstrap.min.js') }}"></script>
     <script src="{{ url_for('static', filename='scripts/js/main.js') }}"></script>


### PR DESCRIPTION
Just a quick update to the tutorial now that react-dom has split off from react ( https://facebook.github.io/react/blog/2015/10/07/react-v0.14.html ).
