### PR TITLE
Remove duplicate code block

### DIFF
--- a/2015/2015-09-08-comparing-python-command-line-parsing-libraries-argparse-docopt-click.markdown
+++ b/2015/2015-09-08-comparing-python-command-line-parsing-libraries-argparse-docopt-click.markdown
@@ -486,29 +486,6 @@ HELLO = """usage: basic.py hello [options] [<name>]
 GOODBYE = """usage: basic.py goodbye [options] [<name>]
 
   -h --help         Show this screen.
-  -"""usage: greet [--help] <command> [<args>...]
-
-options:
-  -h --help         Show this screen.
-
-commands:
-   hello       Say hello
-   goodbye     Say goodbye
-
-"""
-
-from docopt import docopt
-
-HELLO = """usage: basic.py hello [options] [<name>]
-
-  -h --help         Show this screen.
-  --caps            Uppercase the output.
-  --greeting=<str>  Greeting to use [default: Hello].
-"""
-
-GOODBYE = """usage: basic.py goodbye [options] [<name>]
-
-  -h --help         Show this screen.
   --caps            Uppercase the output.
   --greeting=<str>  Greeting to use [default: Goodbye].
 """


### PR DESCRIPTION
Red-marked area throws off the syntax highlighter, but it also appears to be part of a duplicated code block anyway (probably copy-paste error)

<img width="522" alt="screen shot 2016-08-16 at 15 18 34" src="https://cloud.githubusercontent.com/assets/1127221/17702459/e6db1594-63c5-11e6-93e2-258af7e58b4e.png">
