### PR TITLE
Django redis cache blog, no such table error

### DIFF
--- a/2016/2016-09-20-caching-in-django-with-redis.markdown
+++ b/2016/2016-09-20-caching-in-django-with-redis.markdown
@@ -45,6 +45,7 @@ Install all of the required Python dependencies with `pip`, and then checkout th
 Finish setting up the example app by building the database and populating it with sample data. Make sure to create a superuser too, so that you can log into the admin site. Follow the code examples below and then try running the app to make sure it is working correctly. Visit the admin page in the browser to confirm that the data has been properly loaded.
 
 ```sh
+(django-redis)$ python manage.py makemigrations cookbook
 (django-redis)$ python manage.py migrate
 (django-redis)$ python manage.py createsuperuser
 (django-redis)$ python manage.py loaddata cookbook/fixtures/cookbook.json


### PR DESCRIPTION
Django redis cache [blog](https://github.com/realpython/realpython-blog/blob/master/2016/2016-09-20-caching-in-django-with-redis.markdown) had one issue, after following given steps when we load data it gives below error because cookbook apps tables are not migrated.

django.db.utils.OperationalError: Problem installing fixture '/Users/viveks/Repos/Learning/django-redis-cache/cookbook/fixtures/cookbook.json': Could not load cookbook.Recipe(pk=1): no such table: cookbook_recipe

Please find the issue for reference. 
https://github.com/realpython/django-redis-cache/issues/1

Fixed it by adding command to migrate cookbook app tables before loading data